### PR TITLE
uraniborg/Hubble: Housekeeping on build params and deprecations.

### DIFF
--- a/uraniborg/AndroidStudioProject/Hubble/app/build.gradle
+++ b/uraniborg/AndroidStudioProject/Hubble/app/build.gradle
@@ -17,10 +17,10 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
-    namespace 'com.uraniborg.hubble'
+    namespace = 'com.uraniborg.hubble'
 }
 
 dependencies {
@@ -31,4 +31,8 @@ dependencies {
     androidTestImplementation 'androidx.test:runner:1.7.0'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.7.0'
     implementation 'org.jetbrains:annotations:26.1.0'
+}
+
+tasks.withType(JavaCompile) {
+    options.compilerArgs << "-Xlint:deprecation"
 }

--- a/uraniborg/AndroidStudioProject/Hubble/app/src/main/java/com/uraniborg/hubble/MainActivity.java
+++ b/uraniborg/AndroidStudioProject/Hubble/app/src/main/java/com/uraniborg/hubble/MainActivity.java
@@ -95,6 +95,7 @@ public class MainActivity extends AppCompatActivity {
   // this allows us to get APEX packages when calling getInstalledPackages
   final int MATCH_APEX = 0x40000000;
 
+  @SuppressWarnings("deprecation")
   private void getInstalledPackagesInformation() {
     String tag = TAG + "-PKGS";
 
@@ -127,6 +128,7 @@ public class MainActivity extends AppCompatActivity {
     Log.d(tag, String.format("There are %d packages (including APEX)", mAllPackages.size()));
   }
 
+  @SuppressWarnings("deprecation")
   private void getAllCertificates() {
     final String tag = TAG + "-CERT";
     for (String pkgName : mAllPackages.keySet()) {

--- a/uraniborg/AndroidStudioProject/Hubble/app/src/main/java/com/uraniborg/hubble/PackageMetadata.java
+++ b/uraniborg/AndroidStudioProject/Hubble/app/src/main/java/com/uraniborg/hubble/PackageMetadata.java
@@ -85,6 +85,7 @@ public class PackageMetadata extends BaseInfo {
    * @param packageManager A valid {@link PackageManager} object used to load app description.
    * @return a valid {@link PackageMetadata} object containing parsed information about the APK.
    */
+  @SuppressWarnings("deprecation")
   static public PackageMetadata parse(Context context, @NotNull PackageInfo packageInfo,
                                       @NotNull PackageManager packageManager) {
     PackageMetadata result = new PackageMetadata();
@@ -494,6 +495,7 @@ public class PackageMetadata extends BaseInfo {
    * {@link PackageMetadata#permissionsDeclared} field.
    * @return <code>true</code> if no errors were encountered. <code>false</code> otherwise.
    */
+  @SuppressWarnings("deprecation")
   public boolean parseDeclaredPermissions() {
     final String TAG = "getDeclaredPerms";
     PermissionInfo[] perms = ref.permissions;


### PR DESCRIPTION
- fixed propName = value warning in app/build.gradle.
- upgraded the project to Java 17 compatibility to resolve the JDK 22 deprecation warning.
- added suppressions in PackageMetadata.java and MainActivity.java for APIs that are used intentionally for backward compatibility.

Test: Manual. `gradlew assemble` builds Hubble APK successfully without
      further warnings now.

Change-Id: Ia390e790e26ff352635215fd211447f902e78e39