### PR TITLE
verifier_tools/verify: bump minimum Go version to 1.24

### DIFF
--- a/verifier_tools/verify/README.md
+++ b/verifier_tools/verify/README.md
@@ -17,15 +17,7 @@ See the particular section for this tool:
   * Internal libraries for the verifier binary.
 
 ## Build
-This module requires Go 1.17. Install [here](https://go.dev/doc/install), and run `go build cmd/verifier/verifier.go`.
-
-If you are building on `macOS 15 (Sequoia)` where all Mach-O executables are mandated to contain the `LC_UUID` load command, you will need to build with extra parameters as below, and then sign the binary.
-This is because when `-linkmode=external` is used, the resulting binary can sometimes end up with an invalid or missing signature. This can be resolved by manually applying an ad-hoc signature to your compiled binary using macOS's built-in `codesign` utility.
-
-```bash
-go build -ldflags="-linkmode=external" -o verifier cmd/verifier/verifier.go
-codesign -s - -f ./verifier
-```
+This module requires Go 1.24. Install [here](https://go.dev/doc/install), and run `go build cmd/verifier/verifier.go`.
 
 An executable named `verifier` should be produced upon successful build.
 

--- a/verifier_tools/verify/go.mod
+++ b/verifier_tools/verify/go.mod
@@ -1,6 +1,6 @@
 module github.com/android/android-binary-transparency/verifier_tools/verify
 
-go 1.17
+go 1.24
 
 require (
 	github.com/google/go-cmp v0.5.7


### PR DESCRIPTION
- Update the required Go version in `go.mod` from 1.17 to 1.24.
- Update the build instructions in `README.md` to reflect the new Go 1.24 requirement.
- Remove the macOS 15 (Sequoia) build and code signing workaround from `README.md`. As of Go 1.24, the internal linker natively generates the `LC_UUID` load command required by macOS and automatically applies valid ad-hoc signatures to Mach-O executables, rendering the `-linkmode=external` flag and manual `codesign` step unnecessary.

Change-Id: Ia3ee2790f37ff3a2f35e150d257447f9be90337f