### PR TITLE
verifier_tools: Add support for Mainline Modules Tessera sharded log.

### DIFF
--- a/verifier_tools/verify/README.md
+++ b/verifier_tools/verify/README.md
@@ -1,14 +1,16 @@
 # Verifier of Binary Transparency for Pixel Factory Images
 
-This repository contains code to read the transparency log for three logs:
+This repository contains code to read the transparency log for four logs:
   * [Pixel Factory Images Binary Transparency](https://developers.google.com/android/binary_transparency/pixel_overview).
   * [Google System APK Transparency](https://developers.google.com/android/binary_transparency/google1p/overview)
   * [Google Product Application Transparency](https://developers.google.com/android/binary_transparency/google_apk/overview)
+  * [Android Mainline Modules Transparency](https://developers.google.com/android/binary_transparency/mainline_modules/log_details)
 
 See the particular section for this tool:
   * [Pixel](https://developers.google.com/android/binary_transparency/pixel_verification#verifying-image-inclusion-inclusion-proof)
   * [Google System APKs](https://developers.google.com/android/binary_transparency/google1p/verification_details#verifying_package_inclusion_inclusion_proof)
   * [Google Product Application](https://developers.google.com/android/binary_transparency/google_apk/verification_details)
+  * [Android Mainline Modules](https://developers.google.com/android/binary_transparency/mainline_modules/log_details)
 
 ## Files and Directories
 * `cmd/verifier/`
@@ -27,11 +29,15 @@ The verifier uses the associated checkpoint (depending on the target log) and th
     * `https://developers.google.com/android/binary_transparency/tile/`
   * Google System APK Transparency Log
     * `https://developers.google.com/android/binary_transparency/google1p/tile/` (old log)
-    * `https://gstatic.com/android/binary_transparency/google1p/jwt/2026/01/tile/` (latest sharded log)
+    * `https://www.gstatic.com/android/binary_transparency/google1p/jwt/2026/01/tile/` (latest sharded log)
   * Google Product Application Transparency Log
-    * `https://gstatic.com/android/binary_transparency/google1p/apk/2026/01/tile/` (old log)
-    * `https://gstatic.com/android/binary_transparency/google1p/apk/2026/02/tile/` (latest Tessera-backed sharded log)
-      * `https://gstatic.com/android/binary_transparency/google1p/apk/2026/02/tile/entries/` (for data leaves)
+    * `https://www.gstatic.com/android/binary_transparency/google1p/apk/2026/01/tile/` (old log)
+    * `https://www.gstatic.com/android/binary_transparency/google1p/apk/2026/02/tile/` (latest Tessera-backed sharded log)
+      * `https://www.gstatic.com/android/binary_transparency/google1p/apk/2026/02/tile/entries/` (for data leaves)
+  * Android Mainline Modules Transparency Log
+    * `https://www.gstatic.com/android/binary_transparency/mainline/2026/01/tile/` (old log)
+    * `https://www.gstatic.com/android/binary_transparency/mainline/2026/02/tile/` (latest Tessera-backed sharded log)
+      * `https://www.gstatic.com/android/binary_transparency/mainline/2026/02/tile/entries/` (for data leaves)
 
 To run the verifier after you have built it in the previous section:
 ```
@@ -41,6 +47,7 @@ where `log_type` is one of the following:
   * `pixel` (for Pixel Factory Images)
   * `google_1p_code` (for Google System APKs)
   * `google_1p_apk` (for Google Product Applications)
+  * `mainline_module` (for Android Mainline Modules)
 
 ### Input
 The verifier takes a `payload_path` and a `log_type` as input.
@@ -67,11 +74,16 @@ Each Google Product Application corresponds to a [payload](https://developers.go
 <hash>\n<hash_description>\n<package_name>\n<package_version_code>\n
 ```
 
-The `hash_description` for Google Product Applications is currently fixed as `SHA256(APK)`.
+The `hash_description` for Google Product Applications could either be `SHA256(APK)` or `SHA256(APEX)` depending on the file type.
 See [here](https://developers.google.com/android/binary_transparency/google_apk/verification_details#construct_a_payload_for_verification) to find out how to construct this payload from a candidate APK.
 
+#### Android Mainline Module
+Each Android Mainline Module corresponds to a [payload](https://developers.google.com/android/binary_transparency/mainline_modules/overview#log_content) stored in the transparency log, the format of which is:
+```
+<hash>\n<hash_description>\n<package_name>\n<package_version_code>\n
+```
 
-
+See [here](https://developers.google.com/android/binary_transparency/google_apk/verification_details#construct_a_payload_for_verification) to find out how to construct this payload from a candidate module APK/APEX.
 
 ### Output
 The output of the command is written to stdout:

--- a/verifier_tools/verify/cmd/verifier/verifier.go
+++ b/verifier_tools/verify/cmd/verifier/verifier.go
@@ -46,7 +46,9 @@ const (
 	LogBaseURLG1PAPK202601           = "https://www.gstatic.com/android/binary_transparency/google1p/apk/2026/01"
 	LogBaseURLG1PAPK202602           = "https://www.gstatic.com/android/binary_transparency/google1p/apk/2026/02"
 	NoteVerifierG1PAPK202602         = "android.transparency.goog/google1p/apk/2026/1+fc654374+ATr9NQE0gvOtVfj5cCStUzdlflEp3oZoNHD8pImzPj5O"
-	LogBaseURLMainlineModule         = "https://www.gstatic.com/android/binary_transparency/mainline/2026/01"
+	LogBaseURLMainlineModule202601   = "https://www.gstatic.com/android/binary_transparency/mainline/2026/01"
+	LogBaseURLMainlineModule202602   = "https://www.gstatic.com/android/binary_transparency/mainline/2026/02"
+	NoteVerifierMainlineModule202602 = "android.transparency.goog/mainline/modules/2026/1+1a8e4064+AfwnHm59rNQTJICchMd7a2W5PQa7nC5h2gTEfq3fhCEI"
 	ImageInfoFilename                = "image_info.txt"
 	PackageInfoFilename              = "package_info.txt"
 	ModuleInfoFilename               = "module_info.txt"
@@ -173,16 +175,32 @@ func main() {
 			binaryInfoFilename: PackageInfoFilename,
 		})
 	case "mainline_module":
-		v, err := checkpoint.NewVerifier(mainlineModuleLogPubKey, KeyNameForVerifierMainlineModule)
+		// Shard 2026/02: Tessera log
+		v2, err := note.NewVerifier(NoteVerifierMainlineModule202602)
 		if err != nil {
-			slog.Error("error creating verifier", "log", "mainline_module", "error", err)
+			slog.Error("error creating verifier for 2026/02 Tessera log", "error", err)
 			os.Exit(1)
 		}
 		targets = append(targets, logTarget{
-			name:               "mainline_module",
-			baseURL:            LogBaseURLMainlineModule,
+			name:           "mainline_module (2026/02 Tessera)",
+			baseURL:        LogBaseURLMainlineModule202602,
+			checkpointPath: "checkpoint",
+			verifier:       v2,
+			tileHeight:     8,
+			isTessera:      true,
+		})
+
+		// Shard 2026/01: Legacy log continuation fallback
+		v1, err := checkpoint.NewVerifier(mainlineModuleLogPubKey, KeyNameForVerifierMainlineModule)
+		if err != nil {
+			slog.Error("error creating verifier for 2026/01 log", "error", err)
+			os.Exit(1)
+		}
+		targets = append(targets, logTarget{
+			name:               "mainline_module (2026/01)",
+			baseURL:            LogBaseURLMainlineModule202601,
 			checkpointPath:     "checkpoint.txt",
-			verifier:           v,
+			verifier:           v1,
 			tileHeight:         8,
 			isTessera:          false,
 			binaryInfoFilename: ModuleInfoFilename,

--- a/verifier_tools/verify/internal/checkpoint/checkpoint.go
+++ b/verifier_tools/verify/internal/checkpoint/checkpoint.go
@@ -47,6 +47,8 @@ const (
 	originIDG1PAPKTessera = "android.transparency.goog/google1p/apk/2026/1\n"
 	// originIDMainlineModule identifies a checkpoint for the Android Mainline Module Transparency Log.
 	originIDMainlineModule = "gstatic.com/android/binary_transparency/mainline/modules/2026/0\n"
+	// originIDMainlineModuleTessera identifies a checkpoint for the Android Mainline Module Transparency Log (Tessera shard).
+	originIDMainlineModuleTessera = "android.transparency.goog/mainline/modules/2026/1\n"
 )
 
 type verifier interface {
@@ -127,13 +129,16 @@ func parseCheckpoint(ckpt string) (Root, error) {
 		body = ckpt[len(originIDG1PAPKTessera):]
 	case strings.HasPrefix(ckpt, originIDMainlineModule):
 		body = ckpt[len(originIDMainlineModule):]
+	case strings.HasPrefix(ckpt, originIDMainlineModuleTessera):
+		body = ckpt[len(originIDMainlineModuleTessera):]
 	default:
-		return Root{}, fmt.Errorf("invalid checkpoint - unknown origin, must be either %s, %s, %s, %s, or %s",
+		return Root{}, fmt.Errorf("invalid checkpoint - unknown origin, must be either %s, %s, %s, %s, %s, or %s",
 			strings.TrimSpace(originIDPixel),
 			strings.TrimSpace(originIDG1P),
 			strings.TrimSpace(originIDG1PAPK),
 			strings.TrimSpace(originIDG1PAPKTessera),
-			strings.TrimSpace(originIDMainlineModule))
+			strings.TrimSpace(originIDMainlineModule),
+			strings.TrimSpace(originIDMainlineModuleTessera))
 	}
 
 	if !strings.HasSuffix(ckpt, "\n") {

--- a/verifier_tools/verify/internal/checkpoint/checkpoint_test.go
+++ b/verifier_tools/verify/internal/checkpoint/checkpoint_test.go
@@ -138,6 +138,11 @@ func TestValidCheckpointFormat(t *testing.T) {
 			m:        "android.transparency.goog/google1p/apk/2026/1\n42\ndGhlIHZpZXcgZnJvbSB0aGUgdHJlZSB0b3BzIGlzIGdyZWF0IQ==\n",
 			wantSize: 42,
 		},
+		{
+			desc:     "mainline module tessera origin",
+			m:        "android.transparency.goog/mainline/modules/2026/1\n14\n1WyF4nQ0ONJUILx/rVTdxFoURKUdeGwHHLeIKCcIYHw=\n",
+			wantSize: 14,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
cmd/verifier/verifier.go:
- configured base URL and note verifier for the Android Mainline Modules Tessera shard (2026/02).
- updated logTarget chain so --log_type=mainline_module checks the latest Tessera shard (2026/02) first, and automatically falls back to the legacy 2026/01 shard if the candidate payload is not found.

internal/checkpoint/checkpoint.go:
- added origin constant `originIDMainlineModuleTessera`.
- updated `parseCheckpoint` to recognize and parse the new Tessera origin (`android.transparency.goog/mainline/modules/2026/1`).

internal/checkpoint/checkpoint_test.go:
- added test case in `TestValidCheckpointFormat` for the new Mainline Modules Tessera checkpoint origin.

README.md:
- added documentation for Android Mainline Modules Transparency Log endpoints (legacy and 2026/02 Tessera shard), `--log_type=mainline_module`, and payload format.
- clarified `hash_description` format for Google Product Applications and Mainline Modules supporting both APK and APEX binaries.

Change-Id: I8c78e2ad9ae9542e8c6e64ee81c395b7adb05d2d